### PR TITLE
Add endpoint to extract and retrieve track information from Spotify URL

### DIFF
--- a/main.py
+++ b/main.py
@@ -68,3 +68,7 @@ def get_playlist_tracks(playlist_id: str = Query(..., description="Spotifyのプ
         return {"playlist_tracks": tracks}
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"エラーが発生しました: {str(e)}")
+    
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="", port=8000)

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import os
 from dotenv import load_dotenv
 from fastapi.middleware.cors import CORSMiddleware
 from urllib.parse import urlparse
+from typing import Optional
 
 # .envファイルを読み込む（環境変数に設定する場合は不要）
 load_dotenv()
@@ -87,6 +88,22 @@ def get_playlist_tracks(playlist_id: str = Query(..., description="Spotifyのプ
         return {"playlist_tracks": tracks}
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"エラーが発生しました: {str(e)}")
+    
+# Spotifyの曲URLからIDを抽出するエンドポイント
+@app.get("/extract_track_id")
+def extract_track_id(track_url: str = Query(..., description="Spotifyの曲URL")):
+    try:
+        if "open.spotify.com" in track_url:
+            parsed_url = urlparse(track_url)
+            path_parts = parsed_url.path.strip("/").split("/")
+            if len(path_parts) == 2 and path_parts[0] == "track":
+                return {"track_id": path_parts[1]}
+        elif track_url.startswith("spotify:track:"):
+            return {"track_id": track_url.split(":")[2]}
+        else:
+            raise ValueError("曲URLの形式が正しくありません")
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"トラックID抽出に失敗しました: {str(e)}")
     
 if __name__ == "__main__":
     import uvicorn

--- a/main.py
+++ b/main.py
@@ -36,6 +36,38 @@ app.add_middleware(
 def read_root():
     return {"Welcome": "This is MusicHub"}
 
+# SpotifyのプレイリストURLからIDを抽出するエンドポイント
+@app.get("/extract_playlist_id")
+def extract_playlist_id(playlist_url: str = Query(..., description="SpotifyのプレイリストURL")):
+    try:
+        if "open.spotify.com" in playlist_url:
+            parsed_url = urlparse(playlist_url)
+            path_parts = parsed_url.path.strip("/").split("/")
+            if len(path_parts) == 2 and path_parts[0] == "playlist":
+                return {"playlist_id": path_parts[1]}
+        elif playlist_url.startswith("spotify:playlist:"):
+            return {"playlist_id": playlist_url.split(":")[2]}
+        else:
+            raise ValueError("プレイリストURLの形式が正しくありません")
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"ID抽出に失敗しました: {str(e)}")
+    
+# Spotifyの曲URLからIDを抽出するエンドポイント
+@app.get("/extract_track_id")
+def extract_track_id(track_url: str = Query(..., description="Spotifyの曲URL")):
+    try:
+        if "open.spotify.com" in track_url:
+            parsed_url = urlparse(track_url)
+            path_parts = parsed_url.path.strip("/").split("/")
+            if len(path_parts) == 2 and path_parts[0] == "track":
+                return {"track_id": path_parts[1]}
+        elif track_url.startswith("spotify:track:"):
+            return {"track_id": track_url.split(":")[2]}
+        else:
+            raise ValueError("曲URLの形式が正しくありません")
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"トラックID抽出に失敗しました: {str(e)}")
+
 # 曲名とアーティスト名を入れるとジャケット画像を取得できるエンドポイント
 @app.get("/get_album_image")
 def get_album_image(track_name: str = Query(..., description="曲名"),
@@ -72,38 +104,6 @@ def get_playlist_tracks(playlist_id: str = Query(..., description="Spotifyのプ
         return {"playlist_tracks": tracks}
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"エラーが発生しました: {str(e)}")
-
-# SpotifyのプレイリストURLからIDを抽出するエンドポイント
-@app.get("/extract_playlist_id")
-def extract_playlist_id(playlist_url: str = Query(..., description="SpotifyのプレイリストURL")):
-    try:
-        if "open.spotify.com" in playlist_url:
-            parsed_url = urlparse(playlist_url)
-            path_parts = parsed_url.path.strip("/").split("/")
-            if len(path_parts) == 2 and path_parts[0] == "playlist":
-                return {"playlist_id": path_parts[1]}
-        elif playlist_url.startswith("spotify:playlist:"):
-            return {"playlist_id": playlist_url.split(":")[2]}
-        else:
-            raise ValueError("プレイリストURLの形式が正しくありません")
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"ID抽出に失敗しました: {str(e)}")
-    
-# Spotifyの曲URLからIDを抽出するエンドポイント
-@app.get("/extract_track_id")
-def extract_track_id(track_url: str = Query(..., description="Spotifyの曲URL")):
-    try:
-        if "open.spotify.com" in track_url:
-            parsed_url = urlparse(track_url)
-            path_parts = parsed_url.path.strip("/").split("/")
-            if len(path_parts) == 2 and path_parts[0] == "track":
-                return {"track_id": path_parts[1]}
-        elif track_url.startswith("spotify:track:"):
-            return {"track_id": track_url.split(":")[2]}
-        else:
-            raise ValueError("曲URLの形式が正しくありません")
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"トラックID抽出に失敗しました: {str(e)}")
     
 if __name__ == "__main__":
     import uvicorn

--- a/main.py
+++ b/main.py
@@ -50,6 +50,21 @@ def get_album_image(track_name: str = Query(..., description="曲名"),
 
     return {"album_image": album_image}
 
+@app.get("/extract_playlist_id")
+def extract_playlist_id(playlist_url: str = Query(..., description="SpotifyのプレイリストURL")):
+    try:
+        if "open.spotify.com" in playlist_url:
+            parsed_url = urlparse(playlist_url)
+            path_parts = parsed_url.path.strip("/").split("/")
+            if len(path_parts) == 2 and path_parts[0] == "playlist":
+                return {"playlist_id": path_parts[1]}
+        elif playlist_url.startswith("spotify:playlist:"):
+            return {"playlist_id": playlist_url.split(":")[2]}
+        else:
+            raise ValueError("プレイリストURLの形式が正しくありません")
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"ID抽出に失敗しました: {str(e)}")
+    
 @app.get("/get_playlist_tracks")
 def get_playlist_tracks(playlist_id: str = Query(..., description="SpotifyのプレイリストID")):
     try:
@@ -73,18 +88,3 @@ def get_playlist_tracks(playlist_id: str = Query(..., description="Spotifyのプ
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="", port=8000)
-
-@app.get("/extract_playlist_id")
-def extract_playlist_id(playlist_url: str = Query(..., description="SpotifyのプレイリストURL")):
-    try:
-        if "open.spotify.com" in playlist_url:
-            parsed_url = urlparse(playlist_url)
-            path_parts = parsed_url.path.strip("/").split("/")
-            if len(path_parts) == 2 and path_parts[0] == "playlist":
-                return {"playlist_id": path_parts[1]}
-        elif playlist_url.startswith("spotify:playlist:"):
-            return {"playlist_id": playlist_url.split(":")[2]}
-        else:
-            raise ValueError("プレイリストURLの形式が正しくありません")
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"ID抽出に失敗しました: {str(e)}")

--- a/main.py
+++ b/main.py
@@ -52,22 +52,6 @@ def get_album_image(track_name: str = Query(..., description="曲名"),
 
     return {"album_image": album_image}
 
-# SpotifyのプレイリストURLからIDを抽出するエンドポイント
-@app.get("/extract_playlist_id")
-def extract_playlist_id(playlist_url: str = Query(..., description="SpotifyのプレイリストURL")):
-    try:
-        if "open.spotify.com" in playlist_url:
-            parsed_url = urlparse(playlist_url)
-            path_parts = parsed_url.path.strip("/").split("/")
-            if len(path_parts) == 2 and path_parts[0] == "playlist":
-                return {"playlist_id": path_parts[1]}
-        elif playlist_url.startswith("spotify:playlist:"):
-            return {"playlist_id": playlist_url.split(":")[2]}
-        else:
-            raise ValueError("プレイリストURLの形式が正しくありません")
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=f"ID抽出に失敗しました: {str(e)}")
-
 # SpotifyのプレイリストIDからプレイリスト内の曲情報を取得するエンドポイント  
 @app.get("/get_playlist_tracks")
 def get_playlist_tracks(playlist_id: str = Query(..., description="SpotifyのプレイリストID")):
@@ -88,6 +72,22 @@ def get_playlist_tracks(playlist_id: str = Query(..., description="Spotifyのプ
         return {"playlist_tracks": tracks}
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"エラーが発生しました: {str(e)}")
+
+# SpotifyのプレイリストURLからIDを抽出するエンドポイント
+@app.get("/extract_playlist_id")
+def extract_playlist_id(playlist_url: str = Query(..., description="SpotifyのプレイリストURL")):
+    try:
+        if "open.spotify.com" in playlist_url:
+            parsed_url = urlparse(playlist_url)
+            path_parts = parsed_url.path.strip("/").split("/")
+            if len(path_parts) == 2 and path_parts[0] == "playlist":
+                return {"playlist_id": path_parts[1]}
+        elif playlist_url.startswith("spotify:playlist:"):
+            return {"playlist_id": playlist_url.split(":")[2]}
+        else:
+            raise ValueError("プレイリストURLの形式が正しくありません")
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"ID抽出に失敗しました: {str(e)}")
     
 # Spotifyの曲URLからIDを抽出するエンドポイント
 @app.get("/extract_track_id")

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from spotipy.oauth2 import SpotifyClientCredentials
 import os
 from dotenv import load_dotenv
 from fastapi.middleware.cors import CORSMiddleware
+from urllib.parse import urlparse
 
 # .envファイルを読み込む（環境変数に設定する場合は不要）
 load_dotenv()
@@ -72,3 +73,18 @@ def get_playlist_tracks(playlist_id: str = Query(..., description="Spotifyのプ
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="", port=8000)
+
+@app.get("/extract_playlist_id")
+def extract_playlist_id(playlist_url: str = Query(..., description="SpotifyのプレイリストURL")):
+    try:
+        if "open.spotify.com" in playlist_url:
+            parsed_url = urlparse(playlist_url)
+            path_parts = parsed_url.path.strip("/").split("/")
+            if len(path_parts) == 2 and path_parts[0] == "playlist":
+                return {"playlist_id": path_parts[1]}
+        elif playlist_url.startswith("spotify:playlist:"):
+            return {"playlist_id": playlist_url.split(":")[2]}
+        else:
+            raise ValueError("プレイリストURLの形式が正しくありません")
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"ID抽出に失敗しました: {str(e)}")

--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ app.add_middleware(
 def read_root():
     return {"Welcome": "This is MusicHub"}
 
+# 曲名とアーティスト名を入れるとジャケット画像を取得できるエンドポイント
 @app.get("/get_album_image")
 def get_album_image(track_name: str = Query(..., description="曲名"),
                     artist_name: str = Query(..., description="アーティスト名")):
@@ -50,6 +51,7 @@ def get_album_image(track_name: str = Query(..., description="曲名"),
 
     return {"album_image": album_image}
 
+# SpotifyのプレイリストURLからIDを抽出するエンドポイント
 @app.get("/extract_playlist_id")
 def extract_playlist_id(playlist_url: str = Query(..., description="SpotifyのプレイリストURL")):
     try:
@@ -64,7 +66,8 @@ def extract_playlist_id(playlist_url: str = Query(..., description="Spotifyの�
             raise ValueError("プレイリストURLの形式が正しくありません")
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"ID抽出に失敗しました: {str(e)}")
-    
+
+# SpotifyのプレイリストIDからプレイリスト内の曲情報を取得するエンドポイント  
 @app.get("/get_playlist_tracks")
 def get_playlist_tracks(playlist_id: str = Query(..., description="SpotifyのプレイリストID")):
     try:
@@ -84,42 +87,6 @@ def get_playlist_tracks(playlist_id: str = Query(..., description="Spotifyのプ
         return {"playlist_tracks": tracks}
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"エラーが発生しました: {str(e)}")
-    
-@app.get("/get_recommendations")
-def get_recommendations(
-    track_id: str = Query(None, description="基準にする曲のID"),
-    artist_id: str = Query(None, description="基準にするアーティストのID"),
-    genre: str = Query(None, description="基準にするジャンル名（例: pop）"),
-    limit: int = Query(10, description="取得する曲数（最大100）")
-):
-    try:
-        seed_tracks = [track_id] if track_id else []
-        seed_artists = [artist_id] if artist_id else []
-        seed_genres = [genre] if genre else []
-
-        if not (seed_tracks or seed_artists or seed_genres):
-            raise HTTPException(status_code=400, detail="track_id、artist_id、genre のうち1つ以上が必要です")
-
-        recommendations = sp.recommendations(
-            seed_tracks=seed_tracks,
-            seed_artists=seed_artists,
-            seed_genres=seed_genres,
-            limit=limit
-        )
-
-        recommended_tracks = []
-        for track in recommendations["tracks"]:
-            recommended_tracks.append({
-                "track_name": track["name"],
-                "artist_name": ", ".join([a["name"] for a in track["artists"]]),
-                "spotify_url": track["external_urls"]["spotify"],
-                "album_image": track["album"]["images"][0]["url"] if track["album"]["images"] else None
-            })
-
-        return {"recommendations": recommended_tracks}
-
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"おすすめ曲の取得に失敗しました: {str(e)}")
     
 if __name__ == "__main__":
     import uvicorn

--- a/main.py
+++ b/main.py
@@ -85,6 +85,42 @@ def get_playlist_tracks(playlist_id: str = Query(..., description="Spotifyのプ
     except Exception as e:
         raise HTTPException(status_code=400, detail=f"エラーが発生しました: {str(e)}")
     
+@app.get("/get_recommendations")
+def get_recommendations(
+    track_id: str = Query(None, description="基準にする曲のID"),
+    artist_id: str = Query(None, description="基準にするアーティストのID"),
+    genre: str = Query(None, description="基準にするジャンル名（例: pop）"),
+    limit: int = Query(10, description="取得する曲数（最大100）")
+):
+    try:
+        seed_tracks = [track_id] if track_id else []
+        seed_artists = [artist_id] if artist_id else []
+        seed_genres = [genre] if genre else []
+
+        if not (seed_tracks or seed_artists or seed_genres):
+            raise HTTPException(status_code=400, detail="track_id、artist_id、genre のうち1つ以上が必要です")
+
+        recommendations = sp.recommendations(
+            seed_tracks=seed_tracks,
+            seed_artists=seed_artists,
+            seed_genres=seed_genres,
+            limit=limit
+        )
+
+        recommended_tracks = []
+        for track in recommendations["tracks"]:
+            recommended_tracks.append({
+                "track_name": track["name"],
+                "artist_name": ", ".join([a["name"] for a in track["artists"]]),
+                "spotify_url": track["external_urls"]["spotify"],
+                "album_image": track["album"]["images"][0]["url"] if track["album"]["images"] else None
+            })
+
+        return {"recommendations": recommended_tracks}
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"おすすめ曲の取得に失敗しました: {str(e)}")
+    
 if __name__ == "__main__":
     import uvicorn
     uvicorn.run(app, host="", port=8000)

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,3 @@
 Hello World !!
+
+made develop branch


### PR DESCRIPTION
## 概要  
このPRでは、新しいエンドポイント `/extract_track_id` を追加。指定されたSpotifyの曲URLからトラックIDを抽出。抽出されたIDは、詳細な曲情報を取得するための基盤

## 変更内容  
- `/extract_track_id` エンドポイントを実装  
  - SpotifyのWeb URL（例: https://open.spotify.com/track/...）およびURI形式（例: spotify:track:...）の両方に対応  
  - トラックIDをパースして返却  
  - 不正な形式や無効なURLに対しては、400エラーを返す